### PR TITLE
fix(react-scroll-hooks): allow more generic container ref

### DIFF
--- a/packages/react-scroll-hooks/package.json
+++ b/packages/react-scroll-hooks/package.json
@@ -8,8 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Sam-Ogden/formzy",
-    "directory": "packages/react-scroll-hooks"
+    "url": "https://github.com/Sam-Ogden/formzy/tree/master/packages/react-scroll-hooks"
   },
   "keywords": [
     "react",

--- a/packages/react-scroll-hooks/src/stories/useScroll.story.tsx
+++ b/packages/react-scroll-hooks/src/stories/useScroll.story.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, RefObject, MutableRefObject, forwardRef } from 'react';
+import React, { useRef, forwardRef, RefObject } from 'react';
 import { number, withKnobs } from '@storybook/addon-knobs';
 import { useScroll } from '..';
 
@@ -9,21 +9,21 @@ export default {
 };
 
 export const ContainerExample = () => {
-  const containerRef = useRef<HTMLElement>() as MutableRefObject<HTMLElement>;
+  const containerRef = useRef<HTMLDivElement>(null);
   const scrollSpeed = number('Scroll Speed', 50);
   const verticalOffset = number('Vertical Offset', 0);
   const { scrollToElement, scrollToY } = useScroll({ scrollSpeed, containerRef });
-  const refs = [useRef<HTMLDivElement>(), useRef<HTMLDivElement>()];
+  const refs = [useRef<HTMLDivElement>(null), useRef<HTMLDivElement>(null)];
   return (
     <>
       <button
-        onClick={() => scrollToElement(refs[0] as MutableRefObject<HTMLDivElement>, verticalOffset)}
+        onClick={() => scrollToElement(refs[0], verticalOffset)}
         className="scroll-to-second-element"
       >
         Scroll to second element
       </button>
       <button
-        onClick={() => scrollToElement(refs[1] as MutableRefObject<HTMLDivElement>, verticalOffset)}
+        onClick={() => scrollToElement(refs[1], verticalOffset)}
         className="scroll-to-last-element"
       >
         scroll to fifth element
@@ -32,7 +32,7 @@ export const ContainerExample = () => {
         Go To Top
       </button>
       <div
-        ref={containerRef as RefObject<HTMLDivElement>}
+        ref={containerRef}
         style={{
           height: '600px',
           border: '2px solid black',
@@ -53,7 +53,7 @@ export const ContainerExample = () => {
 };
 
 const Wrapper = forwardRef((props, ref) => (
-  <div ref={ref as MutableRefObject<HTMLDivElement>} style={{ height: 500 }}>
+  <div ref={ref as RefObject<HTMLDivElement>} style={{ height: 500 }}>
     <p style={{ margin: 0 }}>Some Element</p>
   </div>
 ));

--- a/packages/react-scroll-hooks/src/stories/useScrollSequence.story.tsx
+++ b/packages/react-scroll-hooks/src/stories/useScrollSequence.story.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, MutableRefObject, RefObject, useRef } from 'react';
+import React, { forwardRef, RefObject, useRef } from 'react';
 import { useScrollSequence } from '..';
 import { number, withKnobs } from '@storybook/addon-knobs';
 
@@ -9,7 +9,7 @@ export default {
 };
 
 export const ContainerExample = () => {
-  const containerRef = useRef<HTMLElement>() as MutableRefObject<HTMLElement>;
+  const containerRef = useRef<HTMLElement>(null);
   const { createScrollRef, next, previous, goToPosition, active } = useScrollSequence({
     initialActive: 0,
     verticalOffset: number('Vertical Offset', 50),

--- a/packages/react-scroll-hooks/src/stories/useScrollSequenceDocument.story.tsx
+++ b/packages/react-scroll-hooks/src/stories/useScrollSequenceDocument.story.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, MutableRefObject } from 'react';
+import React, { forwardRef, RefObject } from 'react';
 import { useScrollSequence } from '..';
 import { number, withKnobs } from '@storybook/addon-knobs';
 
@@ -38,7 +38,7 @@ type WrapperProps = {
 };
 const Wrapper = forwardRef(({ index, active }: WrapperProps, ref) => (
   <div
-    ref={ref as MutableRefObject<HTMLDivElement>}
+    ref={ref as RefObject<HTMLDivElement>}
     style={active === index ? { background: 'wheat' } : {}}
   >
     <p style={{ height: 450 }}>Test {index}</p>

--- a/packages/react-scroll-hooks/src/useScroll.tsx
+++ b/packages/react-scroll-hooks/src/useScroll.tsx
@@ -15,7 +15,8 @@ const atBottomOfContainer = (containerRef: MutableRefObject<HTMLElement>) =>
 export const useScroll = (
   options: {
     scrollSpeed?: number;
-    containerRef?: MutableRefObject<HTMLElement>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    containerRef?: MutableRefObject<any>;
   } = {}
 ) => {
   const { scrollSpeed = 40, containerRef = { current: document.documentElement } } = options;
@@ -100,8 +101,8 @@ export const useScroll = (
   }, [y]);
 
   const scrollToY = (y: number) => setY(y < 0 ? 0 : y);
-  const scrollToElement = (element: MutableRefObject<HTMLElement>, verticalOffset = 0) => {
-    const elementOffsetTop = element.current.offsetTop;
+  const scrollToElement = (element: React.RefObject<HTMLElement>, verticalOffset = 0) => {
+    const elementOffsetTop = element?.current?.offsetTop || 0;
     scrollToY(elementOffsetTop - verticalOffset);
   };
 

--- a/packages/react-scroll-hooks/src/useScrollSequence.tsx
+++ b/packages/react-scroll-hooks/src/useScrollSequence.tsx
@@ -1,36 +1,37 @@
-import { MutableRefObject, useLayoutEffect, useRef, useState } from 'react';
+import { MutableRefObject, useLayoutEffect, useRef, useState, RefObject } from 'react';
 import { useSequence, useScroll } from '.';
 
 type Props = {
   initialActive?: number;
   verticalOffset?: number;
   scrollSpeed?: number;
-  containerRef?: MutableRefObject<HTMLElement>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  containerRef?: MutableRefObject<any>;
 };
 
 const useScrollSequence = (options: Props = {}) => {
   const { initialActive = -1, verticalOffset = 0, scrollSpeed = 40, containerRef } = options;
 
   const [length, setLength] = useState(0);
-  const { scrollToElement } = useScroll({ scrollSpeed, containerRef: containerRef || undefined });
+  const { scrollToElement } = useScroll({ scrollSpeed, containerRef });
   const { next, previous, goToPosition, active } = useSequence(length, initialActive);
 
-  let scrollRefs: Array<MutableRefObject<HTMLElement | undefined>> = [];
+  let scrollRefs = useRef<Array<RefObject<HTMLElement>>>([]);
+
   const createScrollRef = () => {
-    const scrollRef = useRef<HTMLElement>();
-    scrollRefs = [...scrollRefs, scrollRef];
-    return { ref: scrollRef, index: scrollRefs.length - 1 };
+    const scrollRef = useRef<HTMLElement>(null);
+    scrollRefs = { current: [...scrollRefs.current, scrollRef] };
+    return { ref: scrollRef, index: scrollRefs.current.length - 1 };
   };
 
   useLayoutEffect(() => {
-    if (scrollRefs[initialActive])
-      scrollToElement(scrollRefs[initialActive] as MutableRefObject<HTMLElement>, verticalOffset);
-    setLength(scrollRefs.length);
+    if (scrollRefs.current[initialActive])
+      scrollToElement(scrollRefs.current[initialActive], verticalOffset);
+    setLength(scrollRefs.current.length);
   }, []);
 
   useLayoutEffect(() => {
-    if (scrollRefs[active])
-      scrollToElement(scrollRefs[active] as MutableRefObject<HTMLElement>, verticalOffset);
+    if (scrollRefs.current[active]) scrollToElement(scrollRefs.current[active], verticalOffset);
   }, [active]);
 
   return { createScrollRef, next, previous, goToPosition, active };


### PR DESCRIPTION
BREAKING CHANGE:
scollToElement ref type changed from MutableRefObject to RefObject